### PR TITLE
Refactor demand flexibility cost PR

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -263,13 +263,17 @@ function _build_model(
             case, demand_flexibility, start_index, end_index
         )
         if !isnothing(demand_flexibility.cost_up)
-            bus_demand_flex_cost_up_amt = Matrix(
-                demand_flexibility.cost_up[start_index:end_index, 2:end]
+            bus_demand_flex_cost_up_amt = transpose(
+                Matrix(
+                    demand_flexibility.cost_up[start_index:end_index, 2:end]
+                )
             )
         end
         if !isnothing(demand_flexibility.cost_dn)
-            bus_demand_flex_cost_dn_amt = Matrix(
-                demand_flexibility.cost_dn[start_index:end_index, 2:end]
+            bus_demand_flex_cost_dn_amt = transpose(
+                Matrix(
+                    demand_flexibility.cost_dn[start_index:end_index, 2:end]
+                )
             )
         end
         if (
@@ -544,14 +548,14 @@ function _build_model(
         # cost for increasing flexible load
         if !isnothing(demand_flexibility.cost_up)
             demand_response_penalty_up = JuMP.@expression(
-                m, sum(sum(bus_demand_flex_cost_up_amt * load_shift_up))
+                m, sum(sum(bus_demand_flex_cost_up_amt .* load_shift_up))
             )
             JuMP.add_to_expression!(obj, demand_response_penalty_up)
         end
         # cost for decreasing flexible load
         if !isnothing(demand_flexibility.cost_dn)
             demand_response_penalty_dn = JuMP.@expression(
-                m, sum(sum(bus_demand_flex_cost_dn_amt * load_shift_dn))
+                m, sum(sum(bus_demand_flex_cost_dn_amt .* load_shift_dn))
             )
             JuMP.add_to_expression!(obj, demand_response_penalty_dn)
         end

--- a/src/model.jl
+++ b/src/model.jl
@@ -263,14 +263,14 @@ function _build_model(
             case, demand_flexibility, start_index, end_index
         )
         if !isnothing(demand_flexibility.cost_up)
-            bus_demand_flex_cost_up_amt = transpose(
+            bus_demand_flex_cost_up = permutedims(
                 Matrix(
                     demand_flexibility.cost_up[start_index:end_index, 2:end]
                 )
             )
         end
         if !isnothing(demand_flexibility.cost_dn)
-            bus_demand_flex_cost_dn_amt = transpose(
+            bus_demand_flex_cost_dn = permutedims(
                 Matrix(
                     demand_flexibility.cost_dn[start_index:end_index, 2:end]
                 )
@@ -548,14 +548,14 @@ function _build_model(
         # cost for increasing flexible load
         if !isnothing(demand_flexibility.cost_up)
             demand_response_penalty_up = JuMP.@expression(
-                m, sum(sum(bus_demand_flex_cost_up_amt .* load_shift_up))
+                m, sum(sum(bus_demand_flex_cost_up .* load_shift_up))
             )
             JuMP.add_to_expression!(obj, demand_response_penalty_up)
         end
         # cost for decreasing flexible load
         if !isnothing(demand_flexibility.cost_dn)
             demand_response_penalty_dn = JuMP.@expression(
-                m, sum(sum(bus_demand_flex_cost_dn_amt .* load_shift_dn))
+                m, sum(sum(bus_demand_flex_cost_dn .* load_shift_dn))
             )
             JuMP.add_to_expression!(obj, demand_response_penalty_dn)
         end

--- a/src/read.jl
+++ b/src/read.jl
@@ -131,32 +131,6 @@ function read_demand_flexibility(filepath)::DemandFlexibility
         demand_flexibility["interval_balance"] = true
         demand_flexibility["rolling_balance"] = true
 
-        # Try reading the cost for down-shifting loads
-        try 
-            println("...loading demand flexibility down-shift cost profiles")
-            demand_flexibility["cost_dn"] = CSV.File(
-                joinpath(filepath, "demand_flexibility_cost_dn.csv")
-            ) |> DataFrames.DataFrame
-        catch e
-            println(
-                "Demand flexibility down-shift cost profiles not found in " * filepath
-            )
-            demand_flexibility["cost_dn"] = nothing
-        end
-
-         # Try reading the cost for up-shifting loads
-        try 
-            println("...loading demand flexibility up-shift cost profiles")
-            demand_flexibility["cost_up"] = CSV.File(
-                joinpath(filepath, "demand_flexibility_cost_up.csv")
-            ) |> DataFrames.DataFrame
-        catch e
-            println(
-                "Demand flexibility up-shift cost profiles not found in " * filepath
-            )
-            demand_flexibility["cost_up"] = nothing
-        end
-
         # Try loading the demand flexibility parameters
         demand_flexibility_parameters = DataFrames.DataFrame()
         try
@@ -199,6 +173,32 @@ function read_demand_flexibility(filepath)::DemandFlexibility
                 "Demand flexibility parameters will default to allowing demand "
                 * "flexibility to occur."
             )
+        end
+        
+        # Try reading the cost for down-shifting loads
+        try 
+            demand_flexibility["cost_dn"] = CSV.File(
+                joinpath(filepath, "demand_flexibility_cost_dn.csv")
+            ) |> DataFrames.DataFrame
+            println("...loading demand flexibility down-shift cost profiles")
+        catch e
+            println(
+                "Demand flexibility down-shift cost profiles not found in " * filepath
+            )
+            demand_flexibility["cost_dn"] = nothing
+        end
+
+        # Try reading the cost for up-shifting loads
+        try 
+            demand_flexibility["cost_up"] = CSV.File(
+                joinpath(filepath, "demand_flexibility_cost_up.csv")
+            ) |> DataFrames.DataFrame
+            println("...loading demand flexibility up-shift cost profiles")
+        catch e
+            println(
+                "Demand flexibility up-shift cost profiles not found in " * filepath
+            )
+            demand_flexibility["cost_up"] = nothing
         end
     end
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -120,44 +120,42 @@ function read_demand_flexibility(filepath)::DemandFlexibility
         demand_flexibility["duration"] = nothing
         demand_flexibility["interval_balance"] = false
         demand_flexibility["rolling_balance"] = false
+        demand_flexibility["cost_up"] = nothing
+        demand_flexibility["cost_dn"] = nothing
     end
 
-    
-    # Try loading demand flexibility cost. If a file is not found, set the field to nothing.
+    # Set the demand flexibility costs and parameters
     if demand_flexibility["enabled"]
-        # try read the cost for down-shifting loads
+        # Pre-specify the demand flexibility parameters
+        demand_flexibility["duration"] = nothing
+        demand_flexibility["interval_balance"] = true
+        demand_flexibility["rolling_balance"] = true
+
+        # Try reading the cost for down-shifting loads
         try 
             println("...loading demand flexibility down-shift cost profiles")
             demand_flexibility["cost_dn"] = CSV.File(
                 joinpath(filepath, "demand_flexibility_cost_dn.csv")
             ) |> DataFrames.DataFrame
         catch e
-            println("Demand flexibility down-shift cost profiles not found in " * filepath)
+            println(
+                "Demand flexibility down-shift cost profiles not found in " * filepath
+            )
             demand_flexibility["cost_dn"] = nothing
         end
-        
-         # try read the cost for up-shifting loads
+
+         # Try reading the cost for up-shifting loads
         try 
             println("...loading demand flexibility up-shift cost profiles")
             demand_flexibility["cost_up"] = CSV.File(
                 joinpath(filepath, "demand_flexibility_cost_up.csv")
             ) |> DataFrames.DataFrame
         catch e
-            println("Demand flexibility up-shift cost profiles not found in " * filepath)
+            println(
+                "Demand flexibility up-shift cost profiles not found in " * filepath
+            )
             demand_flexibility["cost_up"] = nothing
         end
-    end
-
-    
-    
-    # Set the demand flexibility parameters
-    if demand_flexibility["enabled"]
-        # Pre-specify the demand flexibility parameters
-        demand_flexibility["duration"] = nothing
-        demand_flexibility["interval_balance"] = true
-        demand_flexibility["rolling_balance"] = true
-    
-        
 
         # Try loading the demand flexibility parameters
         demand_flexibility_parameters = DataFrames.DataFrame()
@@ -186,7 +184,6 @@ function read_demand_flexibility(filepath)::DemandFlexibility
                 "The parameter that indicates if the rolling load balance constraint "
                 * "is enabled is not defined. Will default to being enabled."
             )
-            
 
             # Try assigning the different demand flexibility parameters from the file
             for k in keys(demand_flexibility_params_errs)

--- a/src/read.jl
+++ b/src/read.jl
@@ -122,12 +122,42 @@ function read_demand_flexibility(filepath)::DemandFlexibility
         demand_flexibility["rolling_balance"] = false
     end
 
+    
+    # Try loading demand flexibility cost. If a file is not found, set the field to nothing.
+    if demand_flexibility["enabled"]
+        # try read the cost for down-shifting loads
+        try 
+            println("...loading demand flexibility down-shift cost profiles")
+            demand_flexibility["cost_dn"] = CSV.File(
+                joinpath(filepath, "demand_flexibility_cost_dn.csv")
+            ) |> DataFrames.DataFrame
+        catch e
+            println("Demand flexibility down-shift cost profiles not found in " * filepath)
+            demand_flexibility["cost_dn"] = nothing
+        end
+        
+         # try read the cost for up-shifting loads
+        try 
+            println("...loading demand flexibility up-shift cost profiles")
+            demand_flexibility["cost_up"] = CSV.File(
+                joinpath(filepath, "demand_flexibility_cost_up.csv")
+            ) |> DataFrames.DataFrame
+        catch e
+            println("Demand flexibility up-shift cost profiles not found in " * filepath)
+            demand_flexibility["cost_up"] = nothing
+        end
+    end
+
+    
+    
     # Set the demand flexibility parameters
     if demand_flexibility["enabled"]
         # Pre-specify the demand flexibility parameters
         demand_flexibility["duration"] = nothing
         demand_flexibility["interval_balance"] = true
         demand_flexibility["rolling_balance"] = true
+    
+        
 
         # Try loading the demand flexibility parameters
         demand_flexibility_parameters = DataFrames.DataFrame()
@@ -156,6 +186,7 @@ function read_demand_flexibility(filepath)::DemandFlexibility
                 "The parameter that indicates if the rolling load balance constraint "
                 * "is enabled is not defined. Will default to being enabled."
             )
+            
 
             # Try assigning the different demand flexibility parameters from the file
             for k in keys(demand_flexibility_params_errs)

--- a/src/types.jl
+++ b/src/types.jl
@@ -44,6 +44,8 @@ end
 
 Base.@kwdef struct DemandFlexibility
     flex_amt::Union{DataFrames.DataFrame,Nothing}
+    cost_dn::Union{DataFrames.DataFrame,Nothing}
+    cost_up::Union{DataFrames.DataFrame,Nothing}
     duration::Union{Int64,Nothing}
     enabled::Bool
     interval_balance::Bool


### PR DESCRIPTION
[Pull Request doc](https://breakthrough-energy.github.io/docs/user/git_guide.html#d-pull-request)

### Purpose
The purpose of this PR is address comments left on the [original PR](https://github.com/Breakthrough-Energy/REISE.jl/pull/135) for integrating a cost for demand flexibility into Breakthrough Energy's REISE.jl framework. The comments mostly pertained to trimming code length and making better use of the `DemandFlexibility` struct. This PR also attempts to include functionality within `loop.jl` that allows the demand flexibility costs to be updated for each interval. Since it is not currently functional, this PR has been left as a draft and will marked as "ready for review" once the issues in `loop.jl` are corrected. Finally, while not addressed in the original PR, there is also a fix to how the demand flexibility cost is calculated in the objective function.

### What the code is doing
In `model.jl`, the `_make_bus_demand_flexibility_cost_amount` function was removed since the demand flexibility costs were already passed at each bus. The bus-level demand flexibility costs are now established within `_build_model`. In response to the comments in the original PR, an array of zeros is no longer created if demand flexibility costs are not present. Instead, the creation of the demand flexibility cost parameters and expressions rely on a check of the appropriate member of the `DemandFlexibility` struct to ensure that the appropriate demand flexibility cost is not `nothing`. During the creation of the demand flexibility cost parameters, we now use `permutedims` to transpose the demand flexibility cost information, resulting in arrays that are of the same dimensions as the `load_shift_up` and `load_shift_dn` variables. This is important for the determination of the demand flexibility cost components of the objective function, which was performing a matrix multiplication rather than an elementwise multiplication (so as to multiply each bus-level cost with each bus-level demand shift). The objective function expression has been updated to perform the elementwise multiplication.

In `read.jl`, the functionality for reading the demand flexibility cost data was moved within one of the existing logic checks.

In `loop.jl`, we try updating demand flexibility cost parameters for intervals `i > 2` by using the built-in JuMP function `set_objective_coefficient`. While this functionality worked on a toy JuMP model, it is throwing an unusual error (see comment below) when running in `loop.jl`. If we cannot get the `set_objective_coefficient` function to work, which seems to be preferable, we will instead look into redefining the objective function for each interval.

### Testing
I ran local tests on the provided test data. All functionality other than that implemented to `loop.jl` works at this time.

### Where to look
The majority of the changes live in:
- The `interval_loop` function of `loop.jl`
- The `_build_model` function of `model.jl`
- The `read_demand_flexibility` function of `read.jl`

### Time estimate
This should hopefully be a quick review due to familiarity with the original PR. Other than ironing the problem in `loop.jl`, this should hopefully not take more than ten minutes.
